### PR TITLE
Fix: lowercase repo owner name in build image workflow

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -76,6 +76,7 @@ jobs:
         run: | 
           echo "release_name=nightly" >> $GITHUB_ENV
           echo "platform_tag=$( echo ${{ matrix.platform }} | tr '/' '-' )" >> $GITHUB_ENV
+          echo "repository_owner_lower=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
           
       - name: Set build tag
         if: |
@@ -114,7 +115,7 @@ jobs:
         with:
           context: ${{ inputs.build_context }}
           file: "${{ inputs.build_context }}/${{ inputs.dockerfile_path }}"
-          tags: "ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:main-${{ env.platform_tag }}"
+          tags: "ghcr.io/${{ env.repository_owner_lower}}/${{ inputs.image_name }}:main-${{ env.platform_tag }}"
           platforms: ${{ matrix.platform }}
           push: true
           provenance: false

--- a/.github/workflows/merge_multiarch_images.yml
+++ b/.github/workflows/merge_multiarch_images.yml
@@ -33,6 +33,10 @@ jobs:
       image: ${{ steps.set_outputs.outputs.image }}
     
     steps:
+      - name: Set required environmental variables
+        run: |
+          echo "repository_owner_lower=${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_ENV
+
       - name: Login to temporary registry
         uses: docker/login-action@v2
         with:
@@ -43,7 +47,7 @@ jobs:
       - uses: int128/docker-manifest-create-action@v1
         name: Merge and push
         with:
-          tags: ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:main
+          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main
           suffixes: ${{ inputs.architecture_suffixes}}
       
       - name: Prune old images
@@ -57,5 +61,5 @@ jobs:
       - name: Set workflow outputs
         id: set_outputs
         run: |
-          echo "image=ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:main" >> $GITHUB_OUTPUT
+          echo "image=ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main" >> $GITHUB_OUTPUT
   


### PR DESCRIPTION
## Description

Lowercase repo owner name in build image workflow

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

