### PR TITLE
Add possibility tu use image prefix

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           context: ${{ inputs.build_context }}
           file: "${{ inputs.build_context }}/${{ inputs.dockerfile_path }}"
-          tags: "ghcr.io/${{ env.repository_owner_lower}}/${{ inputs.image_name }}:main-${{ env.platform_tag }}"
+          tags: "ghcr.io/${{ env.repository_owner_lower}}/${{ inputs.image_name }}:main${{ inputs.image_tag_prefix }}-${{ env.platform_tag }}"
           platforms: ${{ matrix.platform }}
           push: true
           provenance: false

--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           context: ${{ inputs.build_context }}
           file: "${{ inputs.build_context }}/${{ inputs.dockerfile_path }}"
-          tags: "ghcr.io/${{ env.repository_owner_lower}}/${{ inputs.image_name }}:main${{ inputs.image_tag_prefix }}-${{ env.platform_tag }}"
+          tags: "ghcr.io/${{ env.repository_owner_lower}}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
           platforms: ${{ matrix.platform }}
           push: true
           provenance: false
@@ -123,7 +123,7 @@ jobs:
             BUILD_TAG=${{ env.build_tag }}
       
       - name: Scan container image for vulnerabilities
-        if: ${{ inputs.scan_image == true }}
+        if: ${{ fromJson(inputs.scan_image) }}
         uses: flowforge/github-actions-workflows/actions/scan_container_image@main
         with:
-          image_ref: "ghcr.io/${{ github.repository_owner }}/${{ inputs.image_name }}:latest-${{ env.platform_tag }}"
+          image_ref: "ghcr.io/${{ env.repository_owner_lower}}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"

--- a/.github/workflows/merge_multiarch_images.yml
+++ b/.github/workflows/merge_multiarch_images.yml
@@ -7,6 +7,10 @@ on:
         description: 'Name of the image to build'
         required: true
         type: string
+      image_tag_prefix:
+        description: 'Prefix of the image tag'
+        required: false
+        type: string
       architecture_suffixes:
         description: 'Architecture suffixes'
         type: string
@@ -47,7 +51,7 @@ jobs:
       - uses: int128/docker-manifest-create-action@v1
         name: Merge and push
         with:
-          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main
+          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main${{ inputs.image_tag_prefix }}}
           suffixes: ${{ inputs.architecture_suffixes}}
       
       - name: Prune old images

--- a/.github/workflows/merge_multiarch_images.yml
+++ b/.github/workflows/merge_multiarch_images.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: int128/docker-manifest-create-action@v1
         name: Merge and push
         with:
-          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main${{ inputs.image_tag_prefix }}
+          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main
           suffixes: ${{ inputs.architecture_suffixes}}
       
       - name: Prune old images
@@ -65,5 +65,5 @@ jobs:
       - name: Set workflow outputs
         id: set_outputs
         run: |
-          echo "image=ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main" >> $GITHUB_OUTPUT
+          echo "image=ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main" >> $GITHUB_OUTPUT
   

--- a/.github/workflows/merge_multiarch_images.yml
+++ b/.github/workflows/merge_multiarch_images.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: int128/docker-manifest-create-action@v1
         name: Merge and push
         with:
-          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main${{ inputs.image_tag_prefix }}}
+          tags: ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:main${{ inputs.image_tag_prefix }}
           suffixes: ${{ inputs.architecture_suffixes}}
       
       - name: Prune old images


### PR DESCRIPTION
## Description

Use `image_tag_prefix` to add the possibility to customize image tag pushed to temporary registry.

## Related Issue(s)

[#217](https://github.com/FlowFuse/CloudProject/issues/217)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

