### PR TITLE
Add possibility to upload image to ECR only within deploy pipeline

### DIFF
--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -92,8 +92,8 @@ jobs:
         with:
           src: ${{ inputs.image }}
           dst: |
-            ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:nightly${{ inputs.image_tag_prefix }}
-            ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ env.image_tag }}
+            ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}nightly
+            ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}
 
       - name: Configure AWS credentials for EKS interaction
         if: ${{fromJson( inputs.deploy )}}

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -20,6 +20,10 @@ on:
         description: 'Image to deploy'
         type: string
         required: true
+      image_tag_prefix:
+        description: 'Image tag prefix'
+        type: string
+        required: false
       deployment_name:
         description: 'Kubernetes deployment name'
         type: string
@@ -58,7 +62,7 @@ jobs:
       - name: Set unique image tag
         id: set-image-tag
         run: |
-          echo "image_tag=nightly-$(date +%Y%m%d%H%m%S)" >> $GITHUB_ENV
+          echo "image_tag=nightly${{ inputs.image_tag_prefix }}-$(date +%Y%m%d%H%m%S)" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         id: aws-config
@@ -88,7 +92,7 @@ jobs:
         with:
           src: ${{ inputs.image }}
           dst: |
-            ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:nightly
+            ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:nightly${{ inputs.image_tag_prefix }}
             ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ env.image_tag }}
 
       - name: Configure AWS credentials for EKS interaction

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -96,7 +96,7 @@ jobs:
             ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ env.image_tag }}
 
       - name: Configure AWS credentials for EKS interaction
-        if: toJson(${{ inputs.deploy }})
+        if: fromJson(${{ inputs.deploy }})
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
@@ -106,18 +106,18 @@ jobs:
           role-duration-seconds: 1200
 
       - name: Setup kubectl
-        if: toJson(${{ inputs.deploy }})
+        if: fromJson(${{ inputs.deploy }})
         uses: azure/setup-kubectl@v3
         with:
           version: ${{ inputs.kubectl_version }}
 
       - name: Configure kubectl
-        if: toJson(${{ inputs.deploy }})
+        if: fromJson(${{ inputs.deploy }})
         run: |
           aws eks update-kubeconfig --region eu-west-1 --name ${{ secrets.eks_cluster_name }}
         
       - name: Update image and wait for deployment to finish
-        if: toJson(${{ inputs.deploy }})
+        if: fromJson(${{ inputs.deploy }})
         id: update-image
         timeout-minutes: 5
         run: |
@@ -125,7 +125,7 @@ jobs:
           kubectl -n default rollout status deployment/${{ inputs.deployment_name }}
 
       - name: Rollback failed deployment
-        if: ${{ failure() && steps.update-image.conclusion == 'failure' && toJson(inputs.deploy) }}
+        if: ${{ failure() && steps.update-image.conclusion == 'failure' && fromJson(inputs.deploy) }}
         run: |
           kubectl -n default rollout undo deployment/${{ inputs.deployment_name }}
           kubectl -n default rollout status deployment/${{ inputs.deployment_name }}

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set unique image tag
         id: set-image-tag
         run: |
-          echo "image_tag=nightly${{ inputs.image_tag_prefix }}-$(date +%Y%m%d%H%m%S)" >> $GITHUB_ENV
+          echo "image_tag=nightly-$(date +%Y%m%d%H%m%S)" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
         id: aws-config

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -3,6 +3,11 @@ name: Deploy container image to kubernetes cluster
 on:
   workflow_call:
     inputs:
+      deploy:
+        description: 'Deploy to kubernetes cluster'
+        type: boolean
+        required: true
+        default: true
       service_name:
         description: 'Service name'
         type: string
@@ -87,6 +92,7 @@ jobs:
             ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ env.image_tag }}
 
       - name: Configure AWS credentials for EKS interaction
+        if: toJson(${{ inputs.deploy }})
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
@@ -96,15 +102,18 @@ jobs:
           role-duration-seconds: 1200
 
       - name: Setup kubectl
+        if: toJson(${{ inputs.deploy }})
         uses: azure/setup-kubectl@v3
         with:
           version: ${{ inputs.kubectl_version }}
 
       - name: Configure kubectl
+        if: toJson(${{ inputs.deploy }})
         run: |
           aws eks update-kubeconfig --region eu-west-1 --name ${{ secrets.eks_cluster_name }}
         
       - name: Update image and wait for deployment to finish
+        if: toJson(${{ inputs.deploy }})
         id: update-image
         timeout-minutes: 5
         run: |
@@ -112,7 +121,7 @@ jobs:
           kubectl -n default rollout status deployment/${{ inputs.deployment_name }}
 
       - name: Rollback failed deployment
-        if: ${{ failure() && steps.update-image.conclusion == 'failure'}}
+        if: ${{ failure() && steps.update-image.conclusion == 'failure' && toJson(inputs.deploy) }}
         run: |
           kubectl -n default rollout undo deployment/${{ inputs.deployment_name }}
           kubectl -n default rollout status deployment/${{ inputs.deployment_name }}

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -96,7 +96,7 @@ jobs:
             ${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ env.image_tag }}
 
       - name: Configure AWS credentials for EKS interaction
-        if: fromJson(${{ inputs.deploy }})
+        if: ${{fromJson( inputs.deploy )}}
         uses: aws-actions/configure-aws-credentials@v3
         with:
           aws-access-key-id: ${{ secrets.aws_access_key_id }}
@@ -106,18 +106,18 @@ jobs:
           role-duration-seconds: 1200
 
       - name: Setup kubectl
-        if: fromJson(${{ inputs.deploy }})
+        if: ${{fromJson( inputs.deploy )}}
         uses: azure/setup-kubectl@v3
         with:
           version: ${{ inputs.kubectl_version }}
 
       - name: Configure kubectl
-        if: fromJson(${{ inputs.deploy }})
+        if: ${{fromJson( inputs.deploy )}}
         run: |
           aws eks update-kubeconfig --region eu-west-1 --name ${{ secrets.eks_cluster_name }}
         
       - name: Update image and wait for deployment to finish
-        if: fromJson(${{ inputs.deploy }})
+        if: ${{fromJson( inputs.deploy )}}
         id: update-image
         timeout-minutes: 5
         run: |


### PR DESCRIPTION
## Description

For Node-Red images, we do not make any kind of deployment. Instead, we publish images only.
This change adds a possibility to control if deployment to Kubernetes cluster should happen.
In the future, I plan to create a separate workflow for uploading the image step. 

## Related Issue(s)

[#217](https://github.com/FlowFuse/CloudProject/issues/217)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

