### PR TITLE
FIX: helm deployment crashes when no inline values are passed to the workflow

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -38,6 +38,7 @@ on:
         description: 'Comma separated list of value set for helms. Example: "key1=value1,key2=value2"'
         type: string
         required: false
+        default: ''
       chart_namespace:
         description: 'Kubernetes namespace where chart will be deployed'
         type: string

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Set chart values
         run: |
-          if [ -n "${{ secrets.chart_secret_values }}" ]
+          if [ "${{ secrets.chart_secret_values }}" == "" ]
           then
             echo "VALUES=${{ inputs.chart_values }}" >> $GITHUB_ENV
           else

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -72,7 +72,6 @@ on:
         description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
         required: false
 
-
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -38,7 +38,7 @@ on:
         description: 'Comma separated list of value set for helms. Example: "key1=value1,key2=value2"'
         type: string
         required: false
-        default: ''
+        default: null
       chart_namespace:
         description: 'Kubernetes namespace where chart will be deployed'
         type: string
@@ -92,6 +92,15 @@ jobs:
           role-session-name: GithubActionsRoleSession
           role-duration-seconds: 900
 
+      - name: Set chart values
+        run: |
+          if [ -n "${{ secrets.chart_secret_values }}" ]
+          then
+            echo "VALUES=${{ inputs.chart_values }}" >> $GITHUB_ENV
+          else
+            echo "VALUES=${{ format('{0},{1}', secrets.chart_secret_values, inputs.chart_values) }}" >> $GITHUB_ENV
+          fi
+
       - name: Deploy Helm
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.8
         with:
@@ -101,7 +110,7 @@ jobs:
           chart-repository: ${{ inputs.chart_repository }}
           chart-path: ${{ inputs.chart_path }}
           config-files: ${{ inputs.chart_values_file }}
-          values: ${{ format('{0},{1}', secrets.chart_secret_values, inputs.chart_values) }}
+          values: ${{ env.VALUES }}
           namespace: ${{ inputs.chart_namespace }}
           name: ${{ inputs.chart_name }}
           version: ${{ inputs.chart_version }}


### PR DESCRIPTION
## Description

This PR fixes a problem with helm chart installation within `deploy_helm_chart` reusable workflow when no inline helm chart values (ones used in helm's `--set` flag) are passed to the workflow.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

