### PR TITLE
fix: Update `deploy_container_image.yml` to make `deploy` parameter not required

### DIFF
--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -6,7 +6,7 @@ on:
       deploy:
         description: 'Deploy to kubernetes cluster'
         type: boolean
-        required: true
+        required: false
         default: true
       service_name:
         description: 'Service name'


### PR DESCRIPTION
## Description

 Update `deploy_container_image.yml` to make 'deploy' parameter not required.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

