### PR TITLE
feat: publish trivy container scan results to GitHub Security tab

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -132,7 +132,7 @@ jobs:
       
       - name: Scan container image for vulnerabilities
         if: ${{ fromJson(inputs.scan_image) }}
-        uses: flowforge/github-actions-workflows/actions/scan_container_image@main
+        uses: flowforge/github-actions-workflows/actions/scan_container_image@feat-publish-trivy-to-github-sec
         with:
           image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
           check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }} scan results"

--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -132,7 +132,7 @@ jobs:
       
       - name: Scan container image for vulnerabilities
         if: ${{ fromJson(inputs.scan_image) }}
-        uses: flowforge/github-actions-workflows/actions/scan_container_image@feat-publish-trivy-to-github-sec
+        uses: flowforge/github-actions-workflows/actions/scan_container_image@main
         with:
           image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
           check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"

--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -135,4 +135,4 @@ jobs:
         uses: flowforge/github-actions-workflows/actions/scan_container_image@feat-publish-trivy-to-github-sec
         with:
           image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
-          check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }} scan results"
+          check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"

--- a/actions/scan_container_image/action.yml
+++ b/actions/scan_container_image/action.yml
@@ -35,7 +35,7 @@ runs:
         fi
 
     - name: Scan container image for vulnerabilities
-      uses: aquasecurity/trivy-action@0.16.0
+      uses: aquasecurity/trivy-action@0.17.0
       with:
         image-ref: '${{ inputs.image_ref }}'
         format: 'sarif'

--- a/actions/scan_container_image/action.yml
+++ b/actions/scan_container_image/action.yml
@@ -50,4 +50,3 @@ runs:
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: 'trivy-results.sarif'
-

--- a/actions/scan_container_image/action.yml
+++ b/actions/scan_container_image/action.yml
@@ -50,3 +50,4 @@ runs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: '${{ inputs.check_name }}-trivy-results.sarif'
+        category: '${{ inputs.check_name }} scanning'

--- a/actions/scan_container_image/action.yml
+++ b/actions/scan_container_image/action.yml
@@ -47,6 +47,6 @@ runs:
         scanners: '${{ inputs.security_checks }}'
 
     - name: Upload Trivy scan results to GitHub Security tab
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: 'trivy-results.sarif'

--- a/actions/scan_container_image/action.yml
+++ b/actions/scan_container_image/action.yml
@@ -39,7 +39,7 @@ runs:
       with:
         image-ref: '${{ inputs.image_ref }}'
         format: 'sarif'
-        output: 'trivy-results.sarif'
+        output: '${{ inputs.check_name }}-trivy-results.sarif'
         exit-code: '${{ env.trivy_exit_code }}'
         ignore-unfixed: true
         vuln-type: 'os,library'
@@ -49,4 +49,4 @@ runs:
     - name: Upload Trivy scan results to GitHub Security tab
       uses: github/codeql-action/upload-sarif@v3
       with:
-        sarif_file: 'trivy-results.sarif'
+        sarif_file: '${{ inputs.check_name }}-trivy-results.sarif'

--- a/actions/scan_container_image/action.yml
+++ b/actions/scan_container_image/action.yml
@@ -38,21 +38,16 @@ runs:
       uses: aquasecurity/trivy-action@0.16.0
       with:
         image-ref: '${{ inputs.image_ref }}'
-        format: 'template'
-        template: '@/contrib/junit.tpl'
-        output: 'trivy-junit-results.xml'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
         exit-code: '${{ env.trivy_exit_code }}'
         ignore-unfixed: true
         vuln-type: 'os,library'
         severity: '${{ inputs.severity }}'
         scanners: '${{ inputs.security_checks }}'
 
-    - name: Publish scan results
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: always()
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v2
       with:
-        check_name: '${{ inputs.check_name }}'
-        fail_on: 'nothing'
-        report_individual_runs: true
-        files: |
-          trivy-junit-results.xml
+        sarif_file: 'trivy-results.sarif'
+


### PR DESCRIPTION
## Description

This PR adds the functionality to publish the scan results to the GitHub Security tab using the CodeQL action. This will improve the security analysis of container images and provide better visibility into vulnerabilities.
Additionally, it updates the `aquasecurity/trivy-action` action to version 0.17.0 

## Related Issue(s)

#31 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

