### PR TITLE
fix: Add `security-events` write permissions for container build reusable workflow

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -64,6 +64,7 @@ jobs:
       contents: write
       checks: write
       pull-requests: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

This PR adds a `security-events` write permissions to the container build workflow. As a result, the pipeline will be able to publish Trivy scan results to the GitHub Security tab.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

