### PR TITLE
feat: Use sensitive values from 1Password vault in helm deployment workflow

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -3,8 +3,49 @@ name: Deploy helm chart to EKS cluster
 on:
   workflow_call:
     inputs:
-      environment:
-        description: 'Environment to deploy to'
+      chart_action:
+        description: 'Helm action to perform'
+        type: string
+        required: false
+        default: 'install'
+      chart_name:
+        description: 'The name of the helm release'
+        type: string
+        required: true
+      chart_namespace:
+        description: 'Kubernetes namespace where chart will be deployed'
+        type: string
+        required: false
+        default: 'default'
+      chart_path:
+        description: 'Path to the Helm chart'
+        type: string
+        required: true
+      chart_repository:
+        description: 'Helm chart repository'
+        type: string
+        required: true
+      chart_secrets_template_values:
+        description: 'Path to the template values file used in conjunction with 1Password'
+        type: string
+        required: false
+        default: null
+      chart_timeout:
+        description: 'The timeout for the helm chart deployment'
+        type: string
+        required: false
+        default: '300s'
+      chart_values:
+        description: 'Comma separated list of value set for helms. Example: "key1=value1,key2=value2"'
+        type: string
+        required: false
+        default: null
+      chart_values_file:
+        description: 'Path to the Helm chart values file'
+        type: string
+        required: false
+      chart_version:
+        description: 'The version of the helm chart'
         type: string
         required: true
       cluster_region:
@@ -12,51 +53,15 @@ on:
         type: string
         required: false
         default: 'eu-west-1'
+      environment:
+        description: 'Environment to deploy to'
+        type: string
+        required: true
       iam_role_name:
         description: 'Name of the IAM role to assume'
         type: string
         required: false
         default: 'K8sAdmin'
-      chart_action:
-        description: 'Helm action to perform'
-        type: string
-        required: false
-        default: 'install'
-      chart_repository:
-        description: 'Helm chart repository'
-        type: string
-        required: true
-      chart_path:
-        description: 'Path to the Helm chart'
-        type: string
-        required: true
-      chart_values_file:
-        description: 'Path to the Helm chart values file'
-        type: string
-        required: false
-      chart_values:
-        description: 'Comma separated list of value set for helms. Example: "key1=value1,key2=value2"'
-        type: string
-        required: false
-        default: null
-      chart_namespace:
-        description: 'Kubernetes namespace where chart will be deployed'
-        type: string
-        required: false
-        default: 'default'
-      chart_name:
-        description: 'The name of the helm release'
-        type: string
-        required: true
-      chart_version:
-        description: 'The version of the helm chart'
-        type: string
-        required: true
-      chart_timeout:
-        description: 'The timeout for the helm chart deployment'
-        type: string
-        required: false
-        default: '300s'
       validate_url:
         description: 'The url(s) to validate after deployment. Multiple values example: "https://example.com|http://example.net"'
         type: string
@@ -65,11 +70,14 @@ on:
       aws_account_id:
         description: 'AWS account ID'
         required: true
+      chart_secret_values:
+        description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
+        required: false
       cluster_name:
         description: 'EKS cluster name'
         required: true
-      chart_secret_values:
-        description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
+      op_token:
+        description: '1Password seervice account token'
         required: false
 
 jobs:
@@ -91,6 +99,18 @@ jobs:
           role-session-name: GithubActionsRoleSession
           role-duration-seconds: 900
 
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v1
+        with:
+          version: 2.25.0
+      
+      - name: Template sensitive value file
+        if: ${{ secrets.op_token != '' && inputs.chart_secrets_template_values != '' }}
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+        run: |
+          op inject -i ${{ inputs.chart_secrets_template_values }} -o sensitive-values.yml
+
       - name: Set chart values
         run: |
           if [ "${{ secrets.chart_secret_values }}" == "" ]
@@ -100,6 +120,24 @@ jobs:
             echo "VALUES=${{ format('{0},{1}', secrets.chart_secret_values, inputs.chart_values) }}" >> $GITHUB_ENV
           fi
 
+      - name: Create chart value files
+        if: ${{ inputs.chart_values != '' || inputs.chart_secrets_template_values != '' }}
+        run: |
+          values="${{ inputs.chart_values }}"
+          secrets="${{ inputs.chart_secret_values }}"
+          value_files=""
+          if [[ -n "$chart_values" ]]; then
+            value_files="$chart_values"
+          fi
+          if [[ -n "$chart_secret_values" ]]; then
+            if [[ -n "$value_files" ]]; then
+              value_files="$value_files,sensitive-values.yml"
+            else
+              value_files="sensitive-values.yml"
+            fi
+          fi
+          echo "VALUE_FILES=${value_files}" >> $GITHUB_ENV
+
       - name: Deploy Helm
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.8
         with:
@@ -108,7 +146,7 @@ jobs:
           cluster-name: ${{ secrets.cluster_name }}
           chart-repository: ${{ inputs.chart_repository }}
           chart-path: ${{ inputs.chart_path }}
-          config-files: ${{ inputs.chart_values_file }}
+          config-files: ${{ env.VALUE_FILES }}
           values: ${{ env.VALUES }}
           namespace: ${{ inputs.chart_namespace }}
           name: ${{ inputs.chart_name }}

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -122,10 +122,10 @@ jobs:
           values="${{ inputs.chart_values_file }}"
           secrets="${{ inputs.chart_values_files_template }}"
           value_files=""
-          if [[ -n "$chart_values" ]]; then
-            value_files="$chart_values"
+          if [[ -n "$values" ]]; then
+            value_files="$values"
           fi
-          if [[ -n "$chart_secret_values" ]]; then
+          if [[ -n "$secrets" ]]; then
             if [[ -n "$value_files" ]]; then
               value_files="$value_files,templated-values.yml"
             else

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -117,7 +117,7 @@ jobs:
           fi
 
       - name: Create chart value files
-        if: ${{ inputs.chart_values != '' || inputs.chart_values_files_template != '' }}
+        if: ${{ inputs.chart_values_file != '' || inputs.chart_values_files_template != '' }}
         run: |
           values="${{ inputs.chart_values_file }}"
           secrets="${{ inputs.chart_values_files_template }}"

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -101,9 +101,9 @@ jobs:
           version: 2.25.0
       
       - name: Template value file
-        if: ${{ secrets.op_token != '' && inputs.chart_values_files_template != '' }}
+        if: ${{ env.OP_SERVICE_ACCOUNT_TOKEN != '' && inputs.chart_values_files_template != '' }}
         env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.op_token }}
         run: |
           op inject -i ${{ inputs.chart_values_files_template }} -o templated-values.yml
 

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -25,11 +25,6 @@ on:
         description: 'Helm chart repository'
         type: string
         required: true
-      chart_secrets_template_values:
-        description: 'Path to the template values file used in conjunction with 1Password'
-        type: string
-        required: false
-        default: null
       chart_timeout:
         description: 'The timeout for the helm chart deployment'
         type: string
@@ -42,6 +37,10 @@ on:
         default: null
       chart_values_file:
         description: 'Path to the Helm chart values file'
+        type: string
+        required: false
+      chart_values_files_template:
+        description: 'Path to the template values file used in conjunction with 1Password'
         type: string
         required: false
       chart_version:
@@ -70,9 +69,6 @@ on:
       aws_account_id:
         description: 'AWS account ID'
         required: true
-      chart_secret_values:
-        description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
-        required: false
       cluster_name:
         description: 'EKS cluster name'
         required: true
@@ -104,12 +100,12 @@ jobs:
         with:
           version: 2.25.0
       
-      - name: Template sensitive value file
-        if: ${{ secrets.op_token != '' && inputs.chart_secrets_template_values != '' }}
+      - name: Template value file
+        if: ${{ secrets.op_token != '' && inputs.chart_values_files_template != '' }}
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
         run: |
-          op inject -i ${{ inputs.chart_secrets_template_values }} -o sensitive-values.yml
+          op inject -i ${{ inputs.chart_values_files_template }} -o templated-values.yml
 
       - name: Set chart values
         run: |
@@ -121,7 +117,7 @@ jobs:
           fi
 
       - name: Create chart value files
-        if: ${{ inputs.chart_values != '' || inputs.chart_secrets_template_values != '' }}
+        if: ${{ inputs.chart_values != '' || inputs.chart_values_files_template != '' }}
         run: |
           values="${{ inputs.chart_values }}"
           secrets="${{ inputs.chart_secret_values }}"
@@ -131,9 +127,9 @@ jobs:
           fi
           if [[ -n "$chart_secret_values" ]]; then
             if [[ -n "$value_files" ]]; then
-              value_files="$value_files,sensitive-values.yml"
+              value_files="$value_files,templated-values.yml"
             else
-              value_files="sensitive-values.yml"
+              value_files="templated-values.yml"
             fi
           fi
           echo "VALUE_FILES=${value_files}" >> $GITHUB_ENV

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -119,8 +119,8 @@ jobs:
       - name: Create chart value files
         if: ${{ inputs.chart_values != '' || inputs.chart_values_files_template != '' }}
         run: |
-          values="${{ inputs.chart_values }}"
-          secrets="${{ inputs.chart_secret_values }}"
+          values="${{ inputs.chart_values_file }}"
+          secrets="${{ inputs.chart_values_files_template }}"
           value_files=""
           if [[ -n "$chart_values" ]]; then
             value_files="$chart_values"

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -1,5 +1,4 @@
 name: Deploy helm chart to EKS cluster
-
 on:
   workflow_call:
     inputs:
@@ -116,7 +115,7 @@ jobs:
             echo "VALUES=${{ format('{0},{1}', secrets.chart_secret_values, inputs.chart_values) }}" >> $GITHUB_ENV
           fi
 
-      - name: Create chart value files
+      - name: Create chart value files parameter
         if: ${{ inputs.chart_values_file != '' || inputs.chart_values_files_template != '' }}
         run: |
           values="${{ inputs.chart_values_file }}"

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -71,6 +71,9 @@ on:
       cluster_name:
         description: 'EKS cluster name'
         required: true
+      chart_secret_values:
+        description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
+        required: false
       op_token:
         description: '1Password seervice account token'
         required: false


### PR DESCRIPTION
## Description

This PR extends existing helm chart deployment reusable workflow by adding a possibility to use sensitive values stored in 1Password vault.
Workflow is extended by:
* 1Password CLI installation step
* render template file step (using [op inject](https://developer.1password.com/docs/cli/secrets-config-files#step-2-use-secret-references-in-your-config-file) approach)
* prepare `VALUE_FILES` environmental variable - coma-separated list of value files used by the helm chart deployment action
Additionally, it sorts input values in a alphabetical order.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/366

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

