### PR TITLE
feat: Add image tag output in the `deploy_container_image` workflow

### DIFF
--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -54,9 +54,6 @@ on:
       image:
         description: 'Image name ang tag'
         value: ${{ jobs.deploy.outputs.image }}
-      full_image:
-        description: 'Full image'
-        value: ${{ jobs.deploy.outputs.full_image }}
 
 jobs:
   deploy:
@@ -67,7 +64,6 @@ jobs:
       contents: read
     outputs:
       image: ${{ steps.set_outputs.outputs.image }}
-      full_image: ${{ steps.set_outputs.outputs.full_image }}
     steps:      
       - name: Set unique image tag
         id: set-image-tag
@@ -143,5 +139,4 @@ jobs:
       - name: Set workflow outputs
         id: set_outputs
         run: |
-          echo "full_image=${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}" >> $GITHUB_OUTPUT
           echo "image=${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -52,7 +52,7 @@ on:
         required: true
     outputs:
       image:
-        description: 'Image name ang tag'
+        description: 'Image name and tag'
         value: ${{ jobs.deploy.outputs.image }}
 
 jobs:

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -58,6 +58,8 @@ jobs:
     permissions:
       packages: read
       contents: read
+    outputs:
+      image: ${{ steps.set_outputs.outputs.image }}
     steps:      
       - name: Set unique image tag
         id: set-image-tag
@@ -129,3 +131,8 @@ jobs:
         run: |
           kubectl -n default rollout undo deployment/${{ inputs.deployment_name }}
           kubectl -n default rollout status deployment/${{ inputs.deployment_name }}
+
+      - name: Set workflow outputs
+        id: set_outputs
+        run: |
+          echo "image=${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -50,6 +50,10 @@ on:
       eks_cluster_name:
         description: 'EKS cluster name'
         required: true
+    outputs:
+      image:
+        description: 'Full image tag'
+        value: ${{ jobs.deploy.outputs.image }}
 
 jobs:
   deploy:

--- a/.github/workflows/deploy_container_image.yml
+++ b/.github/workflows/deploy_container_image.yml
@@ -52,8 +52,11 @@ on:
         required: true
     outputs:
       image:
-        description: 'Full image tag'
+        description: 'Image name ang tag'
         value: ${{ jobs.deploy.outputs.image }}
+      full_image:
+        description: 'Full image'
+        value: ${{ jobs.deploy.outputs.full_image }}
 
 jobs:
   deploy:
@@ -64,6 +67,7 @@ jobs:
       contents: read
     outputs:
       image: ${{ steps.set_outputs.outputs.image }}
+      full_image: ${{ steps.set_outputs.outputs.full_image }}
     steps:      
       - name: Set unique image tag
         id: set-image-tag
@@ -139,4 +143,5 @@ jobs:
       - name: Set workflow outputs
         id: set_outputs
         run: |
-          echo "image=${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}" >> $GITHUB_OUTPUT
+          echo "full_image=${{ steps.aws-config.outputs.aws-account-id }}.dkr.ecr.eu-west-1.amazonaws.com/flowforge/${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}" >> $GITHUB_OUTPUT
+          echo "image=${{ inputs.service_name }}:${{ inputs.image_tag_prefix }}${{ env.image_tag }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Description

This PR updates the `deploy_container_image workflow` to include an output for the image tag of the image pushed to the environment-tied container registry. The output is set in the workflow and can be accessed by other workflows or actions. 

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/230

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

