### PR TITLE
feat: add possibility to test node packages against multiple node versions

### DIFF
--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    name: Build on ${{ matrix.version }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -3,11 +3,6 @@ name: Build and test npm package
 on:
   workflow_call:
     inputs:
-      run_tests:
-        description: 'Run tests'
-        required: false
-        type: boolean
-        default: false
       node:
         description: 'JSON array of Node.js versions and parameters'
         required: false

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -12,7 +12,7 @@ on:
         description: 'Node.js version'
         required: false
         type: string
-        default: '["18"]'
+        default: '[18]'
 
 jobs:
   build:

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -8,11 +8,11 @@ on:
         required: false
         type: boolean
         default: false
-      node_version:
-        description: 'Node.js version'
-        required: false
+      node:
+        description: 'JSON array of Node.js versions and parameters'
+        required: true
         type: string
-        default: '[18]'
+        default: '[{"version": "18", "test": true, "lint": true}]'
 
 jobs:
   build:
@@ -20,23 +20,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          node-version: ${{ fromJson(inputs.node_version)}}
+          node-version: ${{ fromJson(inputs.node)}}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version}}
+      - name: Use Node.js ${{ matrix.version}}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.version }}
   
       - name: Install Dependencies
         run: npm ci
   
       - name: Run lint
+        if: ${{ matrix.lint }}
         run: npm run lint
   
       - name: Run tests
-        if: ${{ fromJson(inputs.run_tests)}}
+        if: ${{ matrix.test }}
         run: npm run test

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -8,21 +8,27 @@ on:
         required: false
         type: boolean
         default: false
+      node_version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '["18.x"]'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          node-version: [16.x]
+          node-version: ${{ fromJson(inputs.node_version)}}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ inputs.node_version }}
+      - name: Use Node.js ${{ matrix.node-version}}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ inputs.node_version }}
+          node-version: ${{ matrix.node_version }}
   
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -20,8 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          node-version: ${{ fromJson(inputs.node)}}
-    name: Build on ${{ matrix.version }}
+          node: ${{ fromJson(inputs.node)}}
+    name: Build on ${{ matrix.node.version }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
           node-version: ${{ fromJson(inputs.node_version)}}
 

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -12,7 +12,7 @@ on:
         description: 'Node.js version'
         required: false
         type: string
-        default: '["18.x"]'
+        default: '["18"]'
 
 jobs:
   build:

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -36,9 +36,9 @@ jobs:
         run: npm ci
   
       - name: Run lint
-        if: ${{ matrix.lint }}
+        if: ${{ fromJson(matrix.lint) }}
         run: npm run lint
   
       - name: Run tests
-        if: ${{ matrix.test }}
+        if: ${{ fromJson(matrix.test) }}
         run: npm run test

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -17,11 +17,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Build on ${{ matrix.version }}
     strategy:
       fail-fast: false
       matrix:
           node-version: ${{ fromJson(inputs.node)}}
+    name: Build on ${{ matrix.version }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -12,7 +12,7 @@ on:
         description: 'JSON array of Node.js versions and parameters'
         required: false
         type: string
-        default: '[{"version": "18", "test": true, "lint": true}]'
+        default: '[{"version": "18", "tests": true, "lint": true}]'
 
 jobs:
   build:
@@ -27,18 +27,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.version}}
+      - name: Use Node.js ${{ matrix.node.version}}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.version }}
+          node-version: ${{ matrix.node.version }}
   
       - name: Install Dependencies
         run: npm ci
   
       - name: Run lint
-        if: ${{ fromJson(matrix.lint) }}
+        if: ${{ fromJson(matrix.node.lint) }}
         run: npm run lint
   
       - name: Run tests
-        if: ${{ fromJson(matrix.test) }}
+        if: ${{ fromJson(matrix.node.tests) }}
         run: npm run test

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -10,7 +10,7 @@ on:
         default: false
       node:
         description: 'JSON array of Node.js versions and parameters'
-        required: true
+        required: false
         type: string
         default: '[{"version": "18", "test": true, "lint": true}]'
 

--- a/.github/workflows/build_node_package.yml
+++ b/.github/workflows/build_node_package.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version}}
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node-version }}
   
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
## Description

This pull request extends the `Build and test npm package` workflow and adds a possibility to lint and test node package against multiple nodejs versions.

## Related Issue(s)

https://github.com/FlowFuse/nr-project-nodes/issues/82

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

