### PR TITLE
Run helm diff againsts server

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -192,6 +192,7 @@ jobs:
                --suppress-output-line-regex "(app.kubernetes.io/version|chart):.*" \
                --three-way-merge \
                --suppress-secrets \
+               --dry-run=server \
                --output dyff >> diff.result
           else
             helm diff upgrade \
@@ -203,6 +204,7 @@ jobs:
               --suppress-output-line-regex "(app.kubernetes.io/version|chart):.*" \
               --three-way-merge \
               --suppress-secrets \
+              --dry-run=server \
               --output dyff > diff.result
           fi
 


### PR DESCRIPTION
## Description

This pull requests assures, that `helm diff` is executed against configured kubernetes api server.
In result, output of the `helm diff` plugin will not show changes created dynamically (like autogenerated passwords).

## Related Issue(s)

closes https://github.com/FlowFuse/github-actions-workflows/issues/58

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

