### PR TITLE
feat: Make NodeJS version configurable for `Build and publish npm package` workflow

### DIFF
--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: 'https://registry.npmjs.org/'
+      node_version:
+        description: 'Node.js version'
+        required: false
+        type: string
+        default: '16'
     secrets:
       npm_registry_token:
         description: 'NPM registry authentication token'
@@ -104,7 +109,7 @@ jobs:
           inputs.build_package
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: ${{ inputs.node_version }}
           registry-url: '${{ inputs.npm_registry_url }}'
           scope: '@flowforge'
           always-auth: true

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -45,7 +45,7 @@ on:
         description: 'Node.js version'
         required: false
         type: string
-        default: '16'
+        default: '18'
     secrets:
       npm_registry_token:
         description: 'NPM registry authentication token'


### PR DESCRIPTION
## Description

This pull request adds a possibilioty to configure NodeJS version as a workflow input instead of hardcoded within `Build and publish npm package` pipeline.
It also updates default NodeJS version fromm 16 to 18.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

