### PR TITLE
feat: Add possibility to notify on Slack about helm chart deployment

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -327,7 +327,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "${{ inputs.chart_name }} ${{ inputs.environment }} deployment started (In Progress)"",
+                    "text": "${{ inputs.chart_name }} ${{ inputs.environment }} deployment started (In Progress)",
                     "emoji": true
                   }
                 },

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -354,8 +354,6 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
 
       - name: Deploy Helm
-        # for testing purposes
-        if: false 
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
         id: deploy
         with:
@@ -372,10 +370,7 @@ jobs:
           atomic: true
           helm-wait: true
           timeout: ${{ inputs.chart_timeout }}
-      
-      - name: Deploy (simulate failure)
-        id: deploy2
-        run: sleep 15 && exit 1
+
 
       - name: Validate deployment
         if: ${{ inputs.validate_url != '' }}

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -404,7 +404,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n${{ steps.deploy2.outcome == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                      "text": "*Status:*\n${{ steps.deploy.outcome == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -373,9 +373,9 @@ jobs:
           helm-wait: true
           timeout: ${{ inputs.chart_timeout }}
       
-      - name: Deploy (simulate)
+      - name: Deploy (simulate failure)
         id: deploy2
-        run: sleep 15
+        run: sleep 15 && exit 1
 
       - name: Validate deployment
         if: ${{ inputs.validate_url != '' }}

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -374,6 +374,7 @@ jobs:
           timeout: ${{ inputs.chart_timeout }}
       
       - name: Deploy (simulate)
+        id: deploy2
         run: sleep 15
 
       - name: Validate deployment
@@ -410,7 +411,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n${{ needs.deploy.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                      "text": "*Status:*\n${{ needs.deploy2.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -388,9 +388,7 @@ jobs:
           retry-all: false
 
       - name: Update notification
-        if: |
-          ${{ fromJson( inputs.slack_notification_enabled ) }}  &&
-          ( success() || failure() )
+        if: ${{ always() && fromJson( inputs.slack_notification_enabled ) }}
         uses: slackapi/slack-github-action@v1.26.0
         with:
           channel-id: ${{ inputs.slack_channel_id }}

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -411,7 +411,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n${{ needs.deploy2.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                      "text": "*Status:*\n${{ steps.deploy2.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -317,7 +317,7 @@ jobs:
       - name: Send notification
         uses: slackapi/slack-github-action@v1.26.0
         id: send_notification
-        if: ${{ inputs.slack_notification_enabled }} == 'true'
+        if: ${{ fromJson( inputs.slack_notification_enabled ) }} 
         with:
           channel-id: ${{ inputs.slack_channel_id }}
           payload: |
@@ -389,7 +389,7 @@ jobs:
 
       - name: Update notification
         if: |
-          ${{ inputs.slack_notification_enabled }} == 'true' &&
+          ${{ fromJson( inputs.slack_notification_enabled ) }}  &&
           ( success() || failure() )
         uses: slackapi/slack-github-action@v1.26.0
         with:

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -411,7 +411,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n${{ steps.deploy2.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                      "text": "*Status:*\n${{ steps.deploy2.outcome == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -336,7 +336,7 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n':large_yellow_square: In Progress'"
+                      "text": "*Status:*\n:large_yellow_square: In Progress"
                     },
                     {
                       "type": "mrkdwn",
@@ -401,7 +401,7 @@ jobs:
                   "type": "header",
                   "text": {
                     "type": "plain_text",
-                    "text": "${{ inputs.chart_name }} ${{ inputs.environment }} deployment finished (Completed)"",
+                    "text": "${{ inputs.chart_name }} ${{ inputs.environment }} deployment finished (Completed)",
                     "emoji": true
                   }
                 },
@@ -409,12 +409,12 @@ jobs:
                   "type": "section",
                   "fields": [
                     {
-                    "type": "mrkdwn",
-                    "text": "*Status:*\n${{ needs.deploy.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                      "type": "mrkdwn",
+                      "text": "*Status:*\n${{ needs.deploy.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": ""*Last Commit Message:*\n${{ env.LAST_COMMIT_MSG }}""
+                      "text": "*Last Commit Message:*\n${{ env.LAST_COMMIT_MSG }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -354,6 +354,8 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
 
       - name: Deploy Helm
+        # for testing purposes
+        if: false 
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
         id: deploy
         with:
@@ -370,6 +372,9 @@ jobs:
           atomic: true
           helm-wait: true
           timeout: ${{ inputs.chart_timeout }}
+      
+      - name: Deploy (simulate)
+        run: sleep 15
 
       - name: Validate deployment
         if: ${{ inputs.validate_url != '' }}

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -336,11 +336,11 @@ jobs:
                   "fields": [
                     {
                       "type": "mrkdwn",
-                      "text": "*Status:*\n$':large_yellow_square: In Progress'"
+                      "text": "*Status:*\n':large_yellow_square: In Progress'"
                     },
                     {
                       "type": "mrkdwn",
-                      "text": ""*Last Commit Message:*\n${{ env.LAST_COMMIT_MSG }}""
+                      "text": "*Last Commit Message:*\n${{ env.LAST_COMMIT_MSG }}"
                     },
                     {
                       "type": "mrkdwn",

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -51,15 +51,15 @@ on:
         type: string
         required: false
         default: 'eu-west-1'
-      environment:
-        description: 'Environment to deploy to'
-        type: string
-        required: true
       deploy_branch:
         description: 'Branch from which helm chart will be installed'
         type: string
         required: false
         default: 'main'
+      environment:
+        description: 'Environment to deploy to'
+        type: string
+        required: true
       iam_role_name:
         description: 'Name of the IAM role to assume'
         type: string
@@ -70,6 +70,16 @@ on:
         type: string
         required: false
         default: 'v1.23.4'
+      slack_notification_enabled:
+        description: 'Enable slack notification'
+        type: boolean
+        required: false
+        default: false
+      slack_channel_id:
+        description: 'Slack channel ID'
+        type: string
+        required: false
+        default: 'C05Q84211L2'
       validate_url:
         description: 'The url(s) to validate after deployment. Multiple values example: "https://example.com|http://example.net"'
         type: string
@@ -295,8 +305,54 @@ jobs:
           fi
           echo "VALUE_FILES=${value_files}" >> $GITHUB_ENV
 
+      - name: Fetch Last Commit Message
+        id: last_commit_msg
+        run: |
+          git fetch --depth=1 origin main
+          echo "LAST_COMMIT_MSG=$(git log --format=%B -n 1 FETCH_HEAD)" >> $GITHUB_ENV
+
+      - name: Send notification
+        uses: slackapi/slack-github-action@v1.26.0
+        id: send_notification
+        if: ${{ inputs.slack_notification_enabled }} == 'true'
+        with:
+          channel-id: ${{ inputs.slack_channel_id }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ inputs.chart_name }} ${{ inputs.environment }} deployment started (In Progress)"",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\n$':large_yellow_square: In Progress'"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": ""*Last Commit Message:*\n${{ env.LAST_COMMIT_MSG }}""
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+
       - name: Deploy Helm
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
+        id: deploy
         with:
           action: ${{ inputs.chart_action }}
           aws-region: ${{ inputs.cluster_region }}
@@ -321,3 +377,46 @@ jobs:
           max-attempts: 3
           retry-delay: 10s
           retry-all: false
+
+      - name: Update notification
+        if: |
+          ${{ inputs.slack_notification_enabled }} == 'true' &&
+          ( success() || failure() )
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          channel-id: ${{ inputs.slack_channel_id }}
+          update-ts: ${{ steps.send_notification.outputs.ts }}
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "${{ inputs.chart_name }} ${{ inputs.environment }} deployment finished (Completed)"",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                    "type": "mrkdwn",
+                    "text": "*Status:*\n${{ needs.deploy.result == 'success' && ':white_check_mark: Success' || ':x: Failure '}}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": ""*Last Commit Message:*\n${{ env.LAST_COMMIT_MSG }}""
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow run:*\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>"
+                    }
+                  ]
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GHBOT_TOKEN }}
+
+          

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -97,6 +97,9 @@ on:
       op_token:
         description: '1Password seervice account token'
         required: false
+      slack_token:
+        description: 'Slack token'
+        required: false
 
 jobs:
   diff:
@@ -348,7 +351,7 @@ jobs:
               ]
             }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
 
       - name: Deploy Helm
         uses: bitovi/github-actions-deploy-eks-helm@v1.2.10
@@ -417,6 +420,5 @@ jobs:
               ]
             }
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GHBOT_TOKEN }}
-
-          
+          SLACK_BOT_TOKEN: ${{ secrets.slack_token }}
+         


### PR DESCRIPTION
## Description

This pull request adds a possibility to notify via Slack about the start and finish helm chart deployment.
Additionally, it sorts inputs in alphabetical order.

## Related Issue(s)

https://github.com/FlowFuse/github-actions-workflows/issues/57

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

