### PR TITLE
feat: Publish helm diff results as a PR comment

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -253,10 +253,6 @@ jobs:
         with:
           filePath: ./summary.md
           comment_tag: 'helm-diff-${{ inputs.environment }}'
-
-      - name: Write the step summary
-        if: github.event_name != 'pull_request'
-        run: cat  >> $GITHUB_STEP_SUMMARY
     
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -248,12 +248,14 @@ jobs:
             fs.writeFileSync('./summary.md', output);
       
       - name: Add diff summary to pull request
+        if: github.event_name == 'pull_request'
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: ./summary.md
           comment_tag: 'helm-diff-${{ inputs.environment }}'
 
       - name: Write the step summary
+        if: github.event_name != 'pull_request'
         run: cat  >> $GITHUB_STEP_SUMMARY
     
   deploy:

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -247,8 +247,13 @@ jobs:
 
             fs.writeFileSync('./summary.md', output);
       
+      - name: Add diff summary to pull request
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: ./summary.md
+
       - name: Write the step summary
-        run: cat ./summary.md >> $GITHUB_STEP_SUMMARY
+        run: cat  >> $GITHUB_STEP_SUMMARY
     
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -251,6 +251,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           filePath: ./summary.md
+          comment_tag: 'helm-diff-${{ inputs.environment }}'
 
       - name: Write the step summary
         run: cat  >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Description

This pull request changes the way how `helm diff` results are handled within the `Deploy helm chart to EKS cluster` reusable workflow.
Instead of posting results as a job summary, action will post a comment to the related PR. This should make the PR review process simpler.

## Related Issue(s)

closes https://github.com/FlowFuse/github-actions-workflows/issues/56

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

