### PR TITLE
feat: Add possibility to annotate grafana dashboards on helm deployment

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -411,7 +411,7 @@ jobs:
           -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
           -d '{
             "time": '$(date +%s%3N)',
-            "tags": ["deployment", "github"],
+            "tags": ["deployment", "github", "${CHART"],
             "text": "Deploy of ${CHART} to ${ENVIRONMENT} from GitHub Actions: ${LAST_COMMIT_MSG}"
           }'
 

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -412,7 +412,7 @@ jobs:
           -d '{
             "time": '$(date +%s%3N)',
             "tags": ["deployment", "github", "${CHART"],
-            "text": "Deploy of ${{ env.CHART }} to ${{ env.ENVIRONMENT }} from GitHub Actions: ${{ env.LAST_COMMIT_MSG }}"
+            "text": "Deploy of ${{ env.CHART }} to ${{ env.ENVIRONMENT }} from GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }'
 
       - name: Update notification

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -106,7 +106,7 @@ on:
         description: 'Grafana service account token'
         required: false
       op_token:
-        description: '1Password seervice account token'
+        description: '1Password service account token'
         required: false
       slack_token:
         description: 'Slack token'

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -2,6 +2,11 @@ name: Deploy helm chart to EKS cluster
 on:
   workflow_call:
     inputs:
+      annotate_grafana:
+        description: 'Annotate Grafana'
+        type: boolean
+        required: false
+        default: false
       chart_action:
         description: 'Helm action to perform'
         type: string
@@ -60,6 +65,10 @@ on:
         description: 'Environment to deploy to'
         type: string
         required: true
+      grafana_domain:
+        description: 'Grafana domain'
+        type: string
+        required: false
       iam_role_name:
         description: 'Name of the IAM role to assume'
         type: string
@@ -93,6 +102,9 @@ on:
         required: true
       chart_secret_values:
         description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
+        required: false
+      grafana_token:
+        description: 'Grafana service account token'
         required: false
       op_token:
         description: '1Password seervice account token'
@@ -386,6 +398,21 @@ jobs:
           max-attempts: 3
           retry-delay: 10s
           retry-all: false
+
+      - name: Annotate Grafana
+        if: ${{ fromJson( inputs.annotate_grafana ) }}
+        env:
+          GRAFANA_URL: ${{ inputs.grafana_domain }}
+          GRAFANA_TOKEN: ${{ secrets.grafana_token }}
+        run: |
+          curl -X POST "${GRAFANA_URL}/api/annotations" \
+          -H "Content-Type: application/json" \
+          -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
+          -d '{
+            "time": '$(date +%s%3N)',
+            "tags": ["deployment", "github"],
+            "text": "New deployment from GitHub Actions"
+          }'
 
       - name: Update notification
         if: ${{ always() && fromJson( inputs.slack_notification_enabled ) }}

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -401,8 +401,10 @@ jobs:
       - name: Annotate Grafana
         if: ${{ fromJson( inputs.annotate_grafana ) }}
         env:
+          CHART: ${{ inputs.chart_name }}
           GRAFANA_URL: ${{ secrets.grafana_domain }}
           GRAFANA_TOKEN: ${{ secrets.grafana_token }}
+          ENVIRONMENT: ${{ inputs.environment }}
         run: |
           curl -X POST "${GRAFANA_URL}/api/annotations" \
           -H "Content-Type: application/json" \
@@ -410,7 +412,7 @@ jobs:
           -d '{
             "time": '$(date +%s%3N)',
             "tags": ["deployment", "github"],
-            "text": "New deployment from GitHub Actions"
+            "text": "Deploy of ${CHART} to ${ENVIRONMENT} from GitHub Actions: ${LAST_COMMIT_MSG}"
           }'
 
       - name: Update notification

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -411,7 +411,7 @@ jobs:
           -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
           -d '{
             "time": '$(date +%s%3N)',
-            "tags": ["deployment", "github", "${{ env.CHART }}", "${{ env.ENVIRONMENT }}"],
+            "tags": ["deployment", "${{ env.CHART }}", "${{ env.ENVIRONMENT }}"],
             "text": "Deploy of ${{ env.CHART }} to ${{ env.ENVIRONMENT }} from GitHub Actions: ${{ env.LAST_COMMIT_MSG }}"
           }'
 

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -412,7 +412,7 @@ jobs:
           -d '{
             "time": '$(date +%s%3N)',
             "tags": ["deployment", "github", "${CHART"],
-            "text": "Deploy of ${CHART} to ${ENVIRONMENT} from GitHub Actions: ${LAST_COMMIT_MSG}"
+            "text": "Deploy of ${{ env.CHART }} to ${{ env.ENVIRONMENT }} from GitHub Actions: ${{ env.LAST_COMMIT_MSG }}"
           }'
 
       - name: Update notification

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -411,8 +411,8 @@ jobs:
           -H "Authorization: Bearer ${GRAFANA_TOKEN}" \
           -d '{
             "time": '$(date +%s%3N)',
-            "tags": ["deployment", "github", "${CHART"],
-            "text": "Deploy of ${{ env.CHART }} to ${{ env.ENVIRONMENT }} from GitHub Actions: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            "tags": ["deployment", "github", "${{ env.CHART }}", "${{ env.ENVIRONMENT }}"],
+            "text": "Deploy of ${{ env.CHART }} to ${{ env.ENVIRONMENT }} from GitHub Actions: ${{ env.LAST_COMMIT_MSG }}"
           }'
 
       - name: Update notification

--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -65,10 +65,6 @@ on:
         description: 'Environment to deploy to'
         type: string
         required: true
-      grafana_domain:
-        description: 'Grafana domain'
-        type: string
-        required: false
       iam_role_name:
         description: 'Name of the IAM role to assume'
         type: string
@@ -102,6 +98,9 @@ on:
         required: true
       chart_secret_values:
         description: 'Comma separated list of value set for helms which should not be exposed in runner logs. Example: "key1=value1,key2=value2"'
+        required: false
+      grafana_domain:
+        description: 'Grafana domain'
         required: false
       grafana_token:
         description: 'Grafana service account token'
@@ -402,7 +401,7 @@ jobs:
       - name: Annotate Grafana
         if: ${{ fromJson( inputs.annotate_grafana ) }}
         env:
-          GRAFANA_URL: ${{ inputs.grafana_domain }}
+          GRAFANA_URL: ${{ secrets.grafana_domain }}
           GRAFANA_TOKEN: ${{ secrets.grafana_token }}
         run: |
           curl -X POST "${GRAFANA_URL}/api/annotations" \


### PR DESCRIPTION
## Description

This pull request extends the `Deploy helm chart to EKS cluster` workflow by adding a possibility to annotate grafana after successfull deployment.

## Related Issue(s)

Closes https://github.com/FlowFuse/CloudProject/issues/468

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

