### PR TITLE
fix: Remove empty platform name from container image tag

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           context: ${{ inputs.build_context }}
           file: "${{ inputs.build_context }}/${{ inputs.dockerfile_path }}"
-          tags: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
+          tags: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main"
           platforms: ${{ inputs.build_platform}}
           load: true
           push: true
@@ -133,8 +133,8 @@ jobs:
         if: ${{ fromJson(inputs.scan_image) }}
         uses: flowforge/github-actions-workflows/actions/scan_container_image@main
         with:
-          image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
-          check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
+          image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main"
+          check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main"
 
       - name: Set workflow outputs
         id: set_outputs


### PR DESCRIPTION
## Description

This PR fixex incorrect intermediate image tag name by removing empty "platform_tag" environmental variable.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

