### PR TITLE
feat(publish_node_package): add possibility to publish from othar branch than a default one

### DIFF
--- a/.github/workflows/build_container_image.yml
+++ b/.github/workflows/build_container_image.yml
@@ -121,7 +121,7 @@ jobs:
         with:
           context: ${{ inputs.build_context }}
           file: "${{ inputs.build_context }}/${{ inputs.dockerfile_path }}"
-          tags: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
+          tags: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main"
           platforms: ${{ inputs.build_platform}}
           load: true
           push: true
@@ -133,8 +133,8 @@ jobs:
         if: ${{ fromJson(inputs.scan_image) }}
         uses: flowforge/github-actions-workflows/actions/scan_container_image@main
         with:
-          image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
-          check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main-${{ env.platform_tag }}"
+          image_ref: "ghcr.io/${{ env.repository_owner_lower }}/${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main"
+          check_name: "${{ inputs.image_name }}:${{ inputs.image_tag_prefix }}main"
 
       - name: Set workflow outputs
         id: set_outputs

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -111,11 +111,17 @@ jobs:
         run: |
           for dependency in $(echo "${{ inputs.package_dependencies }}" | tr '\n' ' ')
           do
-            echo "Updating $dependency to ${{ env.release_name }}"
-            cat package.json | jq ".dependencies[\"$dependency\"] = \"${{ env.release_name }}\"" > package.json-patched
-            mv package.json-patched package.json
+            dependency_name=$(echo $dependency | cut -d'=' -f1)
+            dependency_version=$(echo $dependency | cut -d'=' -f2)
+            if [ "$dependency_name" == "$dependency_version" ]; then
+              dependency_version="nightly"
+            fi
+            dependency_semver=$(npm view $dependency_name dist-tags --json | jq -r --arg version "$dependency_version" '.[$version]')
+            echo "Setting $dependency_name to $dependency_version"
+            npm pkg set dependencies.$dependency_name=$dependency_semver
+            echo "### :package: $dependency_name version: $dependency_semver" >> $GITHUB_STEP_SUMMARY
           done
-          cat package.json  
+          cat package.json
       
       - name: Configure node
         if: |

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -3,6 +3,11 @@ name: Build and publish npm package
 on:
   workflow_call:
     inputs:
+      branch_name:
+        description: 'Name of the branch to build the package from'
+        type: string
+        required: false
+        default: 'main'
       package_name:
         description: 'Name of the package to publish'
         type: string
@@ -76,6 +81,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch_name }}
+          path: ${{ inputs.working_directory}}
 
       - name: Set release name
         id: set_release_name
@@ -116,6 +124,7 @@ jobs:
 
       - name: Build package
         if: ${{ inputs.build_package }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           npm install --@flowforge:registry=${{ inputs.npm_registry_url }}
           npm run build

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -109,6 +109,7 @@ jobs:
         if: ${{ inputs.package_dependencies != '' }}
         working-directory: ${{ inputs.working_directory }}
         run: |
+          echo "## Dependencies used to build package" >> $GITHUB_STEP_SUMMARY
           for dependency in $(echo "${{ inputs.package_dependencies }}" | tr '\n' ' ')
           do
             dependency_name=$(echo $dependency | cut -d'=' -f1)

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -8,31 +8,8 @@ on:
         type: string
         required: false
         default: 'main'
-      repository_name:
-        description: 'Name of the repository to build the package from'
-        type: string
-        required: false
-        default: ${{ github.repository }}
-      package_name:
-        description: 'Name of the package to publish'
-        type: string
-        required: true
-      release_name:
-        description: 'Name of the release.'
-        type: string
-        required: false
-      package_dependencies:
-        description: 'List of dependencies to update'
-        type: string
-        required: false
-        default: ''
       build_package:
         description: 'Build package before publishing'
-        required: false
-        type: boolean
-        default: false
-      publish_package:
-        description: 'Publish package to private registry'
         required: false
         type: boolean
         default: false
@@ -41,21 +18,44 @@ on:
         required: false
         type: boolean
         default: false
-      working_directory:
-        description: 'Working directory'
-        required: false
-        type: string
-        default: '.'
-      npm_registry_url:
-        description: 'NPM registry URL'
-        required: false
-        type: string
-        default: 'https://registry.npmjs.org/'
       node_version:
         description: 'Node.js version'
         required: false
         type: string
         default: '18'
+      npm_registry_url:
+        description: 'NPM registry URL'
+        required: false
+        type: string
+        default: 'https://registry.npmjs.org/'
+      package_dependencies:
+        description: 'List of dependencies to update'
+        type: string
+        required: false
+        default: ''
+      package_name:
+        description: 'Name of the package to publish'
+        type: string
+        required: true
+      publish_package:
+        description: 'Publish package to private registry'
+        required: false
+        type: boolean
+        default: false
+      release_name:
+        description: 'Name of the release.'
+        type: string
+        required: false
+      repository_name:
+        description: 'Name of the repository to build the package from'
+        type: string
+        required: false
+        default: ${{ github.repository }}
+      working_directory:
+        description: 'Working directory'
+        required: false
+        type: string
+        default: '.'
     secrets:
       npm_registry_token:
         description: 'NPM registry authentication token'

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -8,6 +8,11 @@ on:
         type: string
         required: false
         default: 'main'
+      repository_name:
+        description: 'Name of the repository to build the package from'
+        type: string
+        required: false
+        default: ${{ github.repository }}
       package_name:
         description: 'Name of the package to publish'
         type: string
@@ -82,6 +87,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          repository: ${{ inputs.repository_name }}
           ref: ${{ inputs.branch_name }}
           path: ${{ inputs.working_directory}}
 


### PR DESCRIPTION
## Description

This pull request extends the `Build and publish npm package` reusable workflow by adding the possibly to build and publish packages from the feature branch.
Additionally, it simplifies the way of updating dependencies defined in `package.js` file and reorders workflow inputs.

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/389

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

