### PR TITLE
fix(publish_node_package): do not checkout to `working_directory`

### DIFF
--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -94,7 +94,6 @@ jobs:
         with:
           repository: ${{ inputs.repository_name }}
           ref: ${{ inputs.branch_name }}
-          path: ${{ inputs.checkout_directory}}
 
       - name: Set release name
         id: set_release_name

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Publish package
         if: ${{ inputs.publish_package }}
-        working-directory: $${{ inputs.working_directory }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }}
         env:

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: boolean
         default: false
+      checkout_directory:
+        description: 'Directory to checkout the repository to'
+        required: false
+        type: string
+        default: '.'
       disable_ignore_scripts_on_publish:
         description: 'If false, add --ignore-scripts flag to npm publish command'
         required: false
@@ -52,7 +57,7 @@ on:
         required: false
         default: ${{ github.repository }}
       working_directory:
-        description: 'Working directory'
+        description: 'Working directory within $checkout_directory to run commands'
         required: false
         type: string
         default: '.'
@@ -89,7 +94,7 @@ jobs:
         with:
           repository: ${{ inputs.repository_name }}
           ref: ${{ inputs.branch_name }}
-          path: ${{ inputs.working_directory}}
+          path: ${{ inputs.checkout_directory}}
 
       - name: Set release name
         id: set_release_name
@@ -101,13 +106,13 @@ jobs:
           fi
 
       - name: "Set package version"
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
         run: |
           npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d%H%M` --no-git-tag-version
 
       - name: Set dependecies versions
         if: ${{ inputs.package_dependencies != '' }}
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
         run: |
           echo "## Dependencies used to build package" >> $GITHUB_STEP_SUMMARY
           for dependency in $(echo "${{ inputs.package_dependencies }}" | tr '\n' ' ')
@@ -137,7 +142,7 @@ jobs:
 
       - name: Build package
         if: ${{ inputs.build_package }}
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
         run: |
           npm install --@flowforge:registry=${{ inputs.npm_registry_url }}
           npm run build
@@ -156,7 +161,7 @@ jobs:
 
       - name: Publish package
         if: ${{ inputs.publish_package }}
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }}
         env:

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -13,11 +13,6 @@ on:
         required: false
         type: boolean
         default: false
-      checkout_directory:
-        description: 'Directory to checkout the repository to'
-        required: false
-        type: string
-        default: '.'
       disable_ignore_scripts_on_publish:
         description: 'If false, add --ignore-scripts flag to npm publish command'
         required: false
@@ -105,13 +100,13 @@ jobs:
           fi
 
       - name: "Set package version"
-        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           npm version prerelease --preid `git rev-parse --short HEAD`-`date +%Y%m%d%H%M` --no-git-tag-version
 
       - name: Set dependecies versions
         if: ${{ inputs.package_dependencies != '' }}
-        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           echo "## Dependencies used to build package" >> $GITHUB_STEP_SUMMARY
           for dependency in $(echo "${{ inputs.package_dependencies }}" | tr '\n' ' ')
@@ -141,7 +136,7 @@ jobs:
 
       - name: Build package
         if: ${{ inputs.build_package }}
-        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
+        working-directory: ${{ inputs.working_directory }}
         run: |
           npm install --@flowforge:registry=${{ inputs.npm_registry_url }}
           npm run build
@@ -160,7 +155,7 @@ jobs:
 
       - name: Publish package
         if: ${{ inputs.publish_package }}
-        working-directory: ${{ inputs.checkout_directory }}/${{ inputs.working_directory }}
+        working-directory: $${{ inputs.working_directory }}
         run: |
           npm publish ${{ env.NPM_PUBLISH_PARAMETERS }} --tag ${{ env.release_name }}
         env:

--- a/.github/workflows/publish_node_package.yml
+++ b/.github/workflows/publish_node_package.yml
@@ -52,7 +52,7 @@ on:
         required: false
         default: ${{ github.repository }}
       working_directory:
-        description: 'Working directory within $checkout_directory to run commands'
+        description: 'Working directory'
         required: false
         type: string
         default: '.'


### PR DESCRIPTION
## Description

This pull request fixes the code checkout step in `Build and publish npm package` reusable workflow. Fix assures, that checkout is not made to the directory specified in the `working_directory` input since this approach breaks the possibility to build packages located in subdirectory.

## Related Issue(s)

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

