### PR TITLE
fix(deploy_helm_chart): allow to run helm diff on fresh release

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -216,6 +216,7 @@ jobs:
                --suppress-output-line-regex "(app.kubernetes.io/version|chart):.*" \
                --three-way-merge \
                --suppress-secrets \
+               --allow-unreleased \
                --dry-run=server \
                --output dyff >> diff.result
           else
@@ -228,6 +229,7 @@ jobs:
               --suppress-output-line-regex "(app.kubernetes.io/version|chart):.*" \
               --three-way-merge \
               --suppress-secrets \
+              --allow-unreleased \
               --dry-run=server \
               --output dyff > diff.result
           fi


### PR DESCRIPTION
## Description

This pull requests allows to run `helm diff` plugin against unreleased helm installations without a failure. Ad a result, diff output will contain entire manifest if new helm release.

## Related Issue(s)

Closes https://github.com/FlowFuse/github-actions-workflows/issues/76

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

