### PR TITLE
ci: Ensure all workflows/actions receive dedicated release pull request

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -5,6 +5,7 @@
   "include-v-in-tag": true,
   "release-type": "simple",
   "skip-github-release": true,
+  "separate-pull-requests": true,
   "changelog-path": "CHANGELOG.md",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Description

This pull request adjusts the `release-please` configuration to ensure that each reusable workflow/composite action have its own release pull request.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

