### PR TITLE
fix(update-nr-flows): Normalize version variable

### DIFF
--- a/actions/update-nr-flows/action.yml
+++ b/actions/update-nr-flows/action.yml
@@ -16,12 +16,13 @@ runs:
       shell: bash
       run: |
         URL=https://flows.nodered.org
+        VERSION=$(echo "${{ inputs.version }}" | sed -e 's/^[^0-9]*//')
         COUNT=1
         until [ $COUNT -gt 5 ]; do
           sleep 10
           LATEST=`npm info "${{ inputs.package }}" --json version | sed -e 's/"//g'`
           echo "current version $LATEST"
-          if [[ "${{ inputs.version }}" == "$LATEST" ]]
+          if [[ "$VERSION" == "$LATEST" ]]
           then
             break
           fi


### PR DESCRIPTION
## Description

This pull request ensures that any non-numeric prefix is removed from the version input variable. Ie. `v0.13.0` →  `0.13.0` .
This allows a proper version comparision since the one returned by the `npm info` command contains numners only. 

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

