### PR TITLE
fix(deploy_helm_chart): Do not run helm diff against deploy branch

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -115,7 +115,7 @@ on:
 jobs:
   diff:
     runs-on: ubuntu-latest
-    # if: ${{ !contains(format('{0}/{1}', 'refs/heads', inputs.deploy_branch ), github.ref ) }}
+    if: ${{ !contains(format('{0}/{1}', 'refs/heads', inputs.deploy_branch ), github.ref ) }}
     environment: ${{ inputs.environment }}
     permissions:
       contents: read


### PR DESCRIPTION
## Description

This pull request ensures that helm diff job will not be executed against the `deploy_branch`.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

