### PR TITLE
fix: add all org issues to the Product board

### DIFF
--- a/.github/workflows/project-automation.yaml
+++ b/.github/workflows/project-automation.yaml
@@ -11,9 +11,6 @@ on:
 jobs:
   add-to-project-board:
     name: Add issue to project
-    if: | 
-      github.repository != 'FlowFuse/website' &&
-      github.repository != 'FlowFuse/node-red-dashboard'
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token
@@ -45,7 +42,7 @@ jobs:
           label-operator: AND
           project-url: https://github.com/orgs/FlowFuse/projects/10
           github-token: ${{ steps.generate_token.outputs.token }}
-  
+
   add-to-dashboard-backlog:
     name: Add issues to the Dashboard Backlog project board
     if: github.repository == 'FlowFuse/node-red-dashboard'

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,11 @@
+name: Project automations
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_issue_to_relevant_boards:
+    uses: flowfuse/github-actions-workflows/.github/workflows/project-automation.yaml@project-automation/v1
+    secrets:
+      app-client-id: ${{ secrets.GH_BOT_APP_ID }}
+      app-private-key: ${{ secrets.GH_BOT_APP_KEY }}


### PR DESCRIPTION
## Summary
Removes the website / node-red-dashboard exclusion from the shared add-to-project-board job so their issues land on the Product board too, and adds the caller workflow for this repo's own issues.

Part of FlowFuse/admin#587