### PR TITLE
fix: use exact title match when deduping sprint issues in the `Recurring Sprint Issue`

### DIFF
--- a/.github/workflows/recurring_sprint_issue.yml
+++ b/.github/workflows/recurring_sprint_issue.yml
@@ -158,8 +158,9 @@ jobs:
             const existing = await github.rest.search.issuesAndPullRequests({
               q: `repo:${owner}/${repo} is:issue is:open in:title "${title}"`
             });
-            if (existing.data.total_count > 0) {
-              core.info(`Issue already exists: ${title}`);
+            const duplicate = existing.data.items.find((i) => i.title === title);
+            if (duplicate) {
+              core.info(`Issue already exists: #${duplicate.number} ${title}`);
               return;
             }
 


### PR DESCRIPTION
## Description

This pull request fixes the duplicate check in the `Recurring Sprint Issue` workflow so the next sprint's issue is created reliably. The check relied on GitHub's fuzzy issue search count, which matched the current sprint's issue and made the workflow skip creation. It now filters the search to an exact title match, so the issue is created on the first run instead of a later one.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label