### PR TITLE
fix: add top-level text fallback to Slack notifications

### DIFF
--- a/.github/workflows/deploy_helm_chart.yml
+++ b/.github/workflows/deploy_helm_chart.yml
@@ -341,6 +341,7 @@ jobs:
           token: ${{ secrets.slack_token }}
           payload: |
             channel: ${{ inputs.slack_channel_id }}
+            text: "${{ inputs.chart_name }} ${{ inputs.environment }} deployment started (In Progress)"
             blocks:
               - type: "header"
                 text:
@@ -411,6 +412,7 @@ jobs:
           payload: |
             channel: ${{ inputs.slack_channel_id }}
             ts: ${{ steps.send_notification.outputs.ts }}
+            text: "${{ inputs.chart_name }} ${{ inputs.environment }} deployment finished (Completed)"
             blocks:
               - type: "header"
                 text:


### PR DESCRIPTION
## Description

This pull request fixes the warning emitted by the `deploy_helm_chart` reusable workflow when sending Slack notification.

## Related Issue(s)

Closes #153

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label