### PR TITLE
feat: Add certified nodes request to `Certified Nodes Requests` project

### DIFF
--- a/.github/workflows/project-automation.yaml
+++ b/.github/workflows/project-automation.yaml
@@ -60,3 +60,21 @@ jobs:
           labeled: needs-triage
           project-url: https://github.com/orgs/FlowFuse/projects/15
           github-token: ${{ steps.generate_token.outputs.token }}
+
+  add-to-certified-nodes-board:
+    name: Add certified node requests to the Certified Nodes board
+    if: github.repository == 'FlowFuse/CloudProject'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.app-client-id }}
+          private-key: ${{ secrets.app-private-key }}
+          owner: ${{ github.repository_owner }}
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          labeled: area:certified-nodes
+          project-url: https://github.com/orgs/FlowFuse/projects/50
+          github-token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
## Description

This pull request extends the `Add new issues to the Relevant Boards` reusable workflow by adding a job responsible for adding every issue created in the `flowfuse/CloudProject` repository and with `area:certified-nodes` label to the `Certified Nodes Requests` project (project ID: 50).

## Related Issue(s)

Closes https://github.com/FlowFuse/engineering/issues/99

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

